### PR TITLE
Minimal changes to test the storedir and publish dir behavior on azure

### DIFF
--- a/modules/index.nf
+++ b/modules/index.nf
@@ -1,6 +1,8 @@
 
 process INDEX {
     tag "$transcriptome.simpleName"
+    storeDir params.store_dir
+
 
     input:
     path transcriptome 

--- a/nextflow.config
+++ b/nextflow.config
@@ -80,18 +80,23 @@ profiles {
   }
 
   azb {
+    params.store_dir = "az://$AZURE_OUTPUT_STORAGE_CONTAINER_NAME/rnaseq-nf-storedir"
+    params.outdir = "az://$AZURE_OUTPUT_STORAGE_CONTAINER_NAME/rnaseq-nf-publishdir"
     process.container = 'quay.io/nextflow/rnaseq-nf:v1.1'
-    workDir = 'az://nf-scratch/work'
+
     process.executor = 'azurebatch'
-    process.queue = 'nextflow-ci' // replace with your own Azure pool name
+
+    workDir = "az://$AZURE_WORK_STORAGE_CONTAINER_NAME/rnaseq-nf-workdir"
 
     azure {
+
       batch {
-        location = 'westeurope'
+        location = "$AZURE_BATCH_LOCATION"
         accountName = "$AZURE_BATCH_ACCOUNT_NAME" 
         accountKey = "$AZURE_BATCH_ACCOUNT_KEY"
         autoPoolMode = true
-        deletePoolsOnCompletion = true
+        //deletePoolsOnCompletion = true
+        deleteJobsOnCompletion = false
       }
 
       storage {


### PR DESCRIPTION
## Summary

With `nf-azure@0.11.2` version, the SAS token usage was enhanced as part of https://github.com/nextflow-io/nextflow/pull/2576 

Therefore, the default plugin version with `nextflow v21.10.6` is `nf-azure@0.11.2` which doesn't have this enhancement. However, using `nf-azure@0.12.0`, this problem should be resolved.


**NOTE: The expected data is within two blob containers (within same storage account).** 


The generated data is then populated within the following three directories

- `rnaseq-nf-workdir`
- `rnaseq-nf-publishdir`
- `rnaseq-nf-stagedir`



## Step-1 

- I have introduced a few environment variables for testing various iterations

```env
export AZURE_BATCH_ACCOUNT_NAME="FIXME"
export AZURE_BATCH_ACCOUNT_KEY="FIXME"
export AZURE_STORAGE_ACCOUNT_NAME="FIXME"
export AZURE_STORAGE_ACCOUNT_KEY="FIXME"
export AZURE_WORK_STORAGE_CONTAINER_NAME="FIXME" // 👈  Blob container for workdir  
export AZURE_OUTPUT_STORAGE_CONTAINER_NAME="FIXME" // 👈  Blob container for publishdir and storedir
export AZURE_BATCH_LOCATION="FIXME"

export NXF_PLUGINS_DEFAULT=nf-azure@0.12.0 // 👈  Manually update the plugin version (OR delete your `~/.nextflow/plugins/nf-azure-xyz`  

```

- With the highlighted changes, the pipeline runs 

```bash

(base) bash-5.0$ nextflow run rnaseq-nf/main.nf -profile azb 
N E X T F L O W  ~  version 21.10.6
Launching `rnaseq-nf/main.nf` [scruffy_hopper] - revision: 4ba66eb0c8
 R N A S E Q - N F   P I P E L I N E
 ===================================
 transcriptome: /projects/nextflow_on_azure/rnaseq-nf/data/ggal/ggal_1_48850000_49020000.Ggal71.500bpflank.fa
 reads        : /projects/nextflow_on_azure/rnaseq-nf/data/ggal/ggal_gut_{1,2}.fq
 outdir       : az://results/rnaseq-nf-publishdir
 
Uploading local `bin` scripts folder to az://nextflow-workdir/rnaseq-nf-workdir/tmp/22/eab0b6b28cda286c488625c5dafbd6/bin
executor >  azurebatch (4)
[d8/ca25eb] process > RNASEQ:INDEX (ggal_1_48850000_49020000) [100%] 1 of 1 ✔
[c9/c65cea] process > RNASEQ:FASTQC (FASTQC on ggal_gut)      [100%] 1 of 1 ✔
[27/25725f] process > RNASEQ:QUANT (ggal_gut)                 [100%] 1 of 1 ✔
[b2/cd13f7] process > MULTIQC                                 [100%] 1 of 1 ✔

Done! Open the following report in your browser --> az://results/rnaseq-nf-publishdir/multiqc_report.html

Completed at: 03-Mar-2022 15:54:55
Duration    : 1m 34s
CPU hours   : (a few seconds)
Succeeded   : 4

```


## Step-2

Since [`storeDir` is a permanent cache](https://www.nextflow.io/docs/edge/process.html#storedir), we can invoke the pipeline without the usual `-resume` and it can be read from the `rnaseq-nf-stagedir` directory on a different storage container.

Notice that the ` RNASEQ:INDEX ` process is using the results from permanent `cache`

```bash
(base) bash-5.0$ nextflow run rnaseq-nf/main.nf -profile azb 
N E X T F L O W  ~  version 21.10.6
Launching `rnaseq-nf/main.nf` [peaceful_borg] - revision: 4ba66eb0c8
 R N A S E Q - N F   P I P E L I N E
 ===================================
 transcriptome: /projects/code/nextflow_on_azure/rnaseq-nf/data/ggal/ggal_1_48850000_49020000.Ggal71.500bpflank.fa
 reads        : /projects/code/nextflow_on_azure/rnaseq-nf/data/ggal/ggal_gut_{1,2}.fq
 outdir       : az://results/rnaseq-nf-publishdir
 
Uploading local `bin` scripts folder to az://nextflow-workdir/rnaseq-nf-workdir/tmp/6d/d36a14f3ee692ce16ae53587759a54/bin
executor >  azurebatch (3)
[skipped  ] process > RNASEQ:INDEX (ggal_1_48850000_49020000) [100%] 1 of 1, stored: 1 ✔ // 👈  Blob container for workdir  
[86/c5cdfe] process > RNASEQ:FASTQC (FASTQC on ggal_gut)      [100%] 1 of 1 ✔
[df/e92c78] process > RNASEQ:QUANT (ggal_gut)                 [100%] 1 of 1 ✔
[e1/97d98d] process > MULTIQC                                 [100%] 1 of 1 ✔

Done! Open the following report in your browser --> az://results/rnaseq-nf-publishdir/multiqc_report.html

Completed at: 03-Mar-2022 16:01:18
Duration    : 1m 15s
CPU hours   : (a few seconds)
Succeeded   : 3



```